### PR TITLE
timestep dependent on dynamic sample rate, peak detector implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 out/
 
 *.csv
+
+.DS_Store


### PR DESCRIPTION
Python proof of concept for:
- dynamic timestep to get frequencies for fft output
- Peak detector with somewhat reliable precision and low accuracy using Harmonic Product Spectrum

Notes: There is a skew in the frequencies detected, but it can likely be adjusted by multiplicative factor.